### PR TITLE
Handling foreign keys

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -71,7 +71,7 @@ SqlStore.prototype._buildModels = function() {
   var relations = Object.keys(self.resourceConfig.attributes).filter(function(attributeName) {
     var settings = self.resourceConfig.attributes[attributeName]._settings;
     if (!settings) return false;
-    return (settings.__one || settings.__many);
+    return (settings.__one || settings.__many) && !settings.__as;
   });
   relations = _.pick(self.resourceConfig.attributes, relations);
 

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -39,7 +39,8 @@ SqlStore.prototype.initialise = function(resourceConfig) {
 
   self.sequelize = new Sequelize(resourceConfig.resource, self.config.username, self.config.password, {
     dialect: self.config.dialect,
-    logging: self.config.logging || debug
+    logging: self.config.logging || debug,
+    freezeTableName: true
   });
 
   self._buildModels();
@@ -152,9 +153,9 @@ SqlStore.prototype._defineRelationModel = function(relationName, many) {
   });
 
   if (many) {
-    self.baseModel.hasMany(relatedModel, { onDelete: "CASCADE" });
+    self.baseModel.hasMany(relatedModel, { onDelete: "CASCADE", foreignKey: self.resourceConfig.resource + "Id" });
   } else {
-    self.baseModel.hasOne(relatedModel, { onDelete: "CASCADE" });
+    self.baseModel.hasOne(relatedModel, { onDelete: "CASCADE", foreignKey: self.resourceConfig.resource + "Id" });
   }
 
   return relatedModel;
@@ -162,9 +163,7 @@ SqlStore.prototype._defineRelationModel = function(relationName, many) {
 
 SqlStore.prototype._fixObject = function(json) {
   var self = this;
-  var bleh = self.resourceConfig.resource;
-  if (bleh[bleh.length - 1] === "s") bleh = bleh.substring(0, bleh.length - 1);
-  bleh += "Id";
+  var resourceId = self.resourceConfig.resource + "Id";
 
   Object.keys(json).forEach(function(attribute) {
     if (attribute.indexOf(self.resourceConfig.resource + "-") !== 0) return;
@@ -179,7 +178,7 @@ SqlStore.prototype._fixObject = function(json) {
     if (!(val instanceof Array)) val = [ val ];
     val.forEach(function(j) {
       if (j.uid) delete j.uid;
-      if (j[bleh]) delete j[bleh];
+      if (j[resourceId]) delete j[resourceId];
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "coveralls": "2.11.2",
     "plato": "1.5.0",
     "mocha-performance": "0.1.0",
-    "jsonapi-server": "1.0.1"
+    "jsonapi-server": "1.0.2"
   },
   "scripts": {
     "test": "/bin/sh setupDatabase.sh && ./node_modules/mocha/bin/mocha --timeout 20000 -R spec ./test/*.js",


### PR DESCRIPTION
This ensures foreign keys are created as we expect them, rather than Sequelize guessing at what they should be called