### PR TITLE
Use Bluebird's functionality to convert promises to callback style.

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -9,17 +9,6 @@ var _ = {
   omit: require("lodash.omit")
 };
 
-var breakPromise = function(promise, callback) {
-  promise.then(function(i) {
-    return setTimeout(function() { callback(null, i); }, 1);
-  }, function(e) {
-    if (e.message === "ER_EMPTY_QUERY: Query was empty") {
-      return setTimeout(function() { callback(); }, 1);
-    }
-    return setTimeout(function() { callback(e); }, 1);
-  });
-};
-
 var SqlStore = module.exports = function SqlStore(config) {
   this.config = config;
 };
@@ -50,7 +39,7 @@ SqlStore.prototype.initialise = function(resourceConfig) {
 
 SqlStore.prototype.populate = function(callback) {
   var self = this;
-  breakPromise(self.sequelize.sync({ force: true }), function(err) {
+  self.sequelize.sync({ force: true }).asCallback(function(err) {
     if (err) throw err;
 
     async.map(self.resourceConfig.examples, function(exampleJson, asyncCallback) {
@@ -264,13 +253,13 @@ SqlStore.prototype._dealWithTransaction = function(done, callback) {
     isolationLevel: Sequelize.Transaction.ISOLATION_LEVELS.READ_UNCOMMITTED,
     autocommit: false
   };
-  breakPromise(self.sequelize.transaction(transactionOptions), function(err1, transaction) {
+  self.sequelize.transaction(transactionOptions).asCallback(function(err1, transaction) {
     if (err1) return done(err1);
 
     var t = { transaction: transaction };
     var commit = function() {
       var args = arguments;
-      breakPromise(transaction.commit(), function(err2) {
+      transaction.commit().asCallback(function(err2) {
         if (err2) return done(err2);
         return done.apply(null, Array.prototype.slice.call(args));
       });
@@ -311,10 +300,10 @@ SqlStore.prototype._clearAndSetRelationTables = function(theResource, partialRes
         });
 
         async.map(prop, function(item, acallback) {
-          breakPromise(relationModel.create(item, t), function(err4, newRelationModel) {
+          relationModel.create(item, t).asCallback(function(err4, newRelationModel) {
             if (err4) return acallback(err4);
 
-            breakPromise(theResource["add" + uc](newRelationModel, t), acallback);
+            theResource["add" + uc](newRelationModel, t).asCallback(acallback);
           });
         }, taskCallback);
       } else {
@@ -322,12 +311,12 @@ SqlStore.prototype._clearAndSetRelationTables = function(theResource, partialRes
           theResource[keyName].destroy(t);
         }
         if (!prop) {
-          breakPromise(theResource["set" + uc](null, t), taskCallback);
+          theResource["set" + uc](null, t).asCallback(taskCallback);
         } else {
-          breakPromise(relationModel.create(prop, t), function(err3, newRelationModel) {
+          relationModel.create(prop, t).asCallback(function(err3, newRelationModel) {
             if (err3) return taskCallback(err3);
 
-            breakPromise(theResource["set" + uc](newRelationModel, t), taskCallback);
+            theResource["set" + uc](newRelationModel, t).asCallback(taskCallback);
           });
         }
       }
@@ -374,7 +363,7 @@ SqlStore.prototype.search = function(request, callback) {
   };
   var query = _.assign(base, self._generateSearchPagination(request));
 
-  breakPromise(self.baseModel.findAndCount(query), function(err, result) {
+  self.baseModel.findAndCount(query).asCallback(function(err, result) {
     debug(query, err, JSON.stringify(result));
     if (err) return self._errorHandler(err, callback);
 
@@ -390,10 +379,10 @@ SqlStore.prototype.search = function(request, callback) {
 SqlStore.prototype.find = function(request, callback) {
   var self = this;
 
-  breakPromise(self.baseModel.findOne({
+  self.baseModel.findOne({
     where: { id: request.params.id },
     include: self.relationArray
-  }), function(err, theResource) {
+  }).asCallback(function(err, theResource) {
     if (err) return self._errorHandler(err, callback);
 
     // If the resource doesn't exist, error
@@ -420,7 +409,7 @@ SqlStore.prototype.create = function(request, newResource, finishedCallback) {
 
   self._dealWithTransaction(finishedCallback, function(t, finishTransaction) {
 
-    breakPromise(self.baseModel.create(newResource, t), function(err2, theResource) {
+    self.baseModel.create(newResource, t).asCallback(function(err2, theResource) {
       if (err2) return finishTransaction(err2);
 
       self._clearAndSetRelationTables(theResource, newResource, t, function(err){
@@ -438,10 +427,10 @@ SqlStore.prototype.create = function(request, newResource, finishedCallback) {
 SqlStore.prototype.delete = function(request, callback) {
   var self = this;
 
-  breakPromise(self.baseModel.findAll({
+  self.baseModel.findAll({
     where: { id: request.params.id },
     include: self.relationArray
-  }), function(findErr, results) {
+  }).asCallback(function(findErr, results) {
     if (findErr) return self._errorHandler(findErr, callback);
 
     var theResource = results[0];
@@ -456,7 +445,7 @@ SqlStore.prototype.delete = function(request, callback) {
       });
     }
 
-    breakPromise(theResource.destroy(), function(deleteErr) {
+    theResource.destroy().asCallback(function(deleteErr) {
       return callback(deleteErr);
     });
   });
@@ -471,11 +460,11 @@ SqlStore.prototype.update = function(request, partialResource, finishedCallback)
 
   self._dealWithTransaction(finishedCallback, function(t, finishTransaction) {
 
-    breakPromise(self.baseModel.findOne({
+    self.baseModel.findOne({
       where: { id: request.params.id },
       include: self.relationArray,
       transaction: t.transaction
-    }), function(err2, theResource) {
+    }).asCallback(function(err2, theResource) {
       if (err2) return finishTransaction(err2);
 
       // If the resource doesn't exist, error
@@ -491,7 +480,7 @@ SqlStore.prototype.update = function(request, partialResource, finishedCallback)
       self._clearAndSetRelationTables(theResource, partialResource, t, function(err){
         if (err) return finishTransaction(err);
 
-        breakPromise(theResource.update(partialResource, t), function(err3) {
+        theResource.update(partialResource, t).asCallback(function(err3) {
           if (err) return finishTransaction(err3);
           return finishTransaction(null, partialResource);
         });


### PR DESCRIPTION
Bluebird's [`asCallback`](http://bluebirdjs.com/docs/api/ascallback.html) (previously `nodeify`) should work out of the box to convert Sequelize's promises to our preferred callback style.

What do you think @hxoliverrumbelow? Is it this simple? Did I miss something? All the tests still pass.