### PR TITLE
V1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 2015-12-10 - v1.0.0
 2015-12-11 - Foreign relations
 2015-12-11 - v1.0.1
+2015-12-11 - Bump Sequelize to prevent promise warnings + use asCallback() on promises
+2015-12-11 - v1.0.2

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash.assign": "3.2.0",
     "lodash.omit": "3.1.0",
     "lodash.pick": "3.1.0",
-    "sequelize": "3.14.0"
+    "sequelize": "3.14.2"
   },
   "devDependencies": {
     "mocha": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-relationaldb",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Relational data store for jsonapi-server.",
   "keywords": [
     "json:api",


### PR DESCRIPTION
This bumps the version of Sequelize to 3.14.2 to fix issue #9 - promises not being returned

Updates the changelog and version in preparation for a new minor release