### PR TITLE
Enable remote db connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,7 @@
 2015-12-10 - v1.0.0
 2015-12-11 - Foreign relations
 2015-12-11 - v1.0.1
-2015-12-11 - Bump Sequelize to prevent promise warnings + use asCallback() on promises
-2015-12-11 - v1.0.2
+2015-12-15 - Bump Sequelize to prevent promise warnings + use asCallback() on promises
+2015-12-15 - v1.0.2
+2015-12-15 - Enable connections to remote databases
+2015-12-15 - v1.0.3

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -28,6 +28,8 @@ SqlStore.prototype.initialise = function(resourceConfig) {
 
   self.sequelize = new Sequelize(resourceConfig.resource, self.config.username, self.config.password, {
     dialect: self.config.dialect,
+    host: self.config.host,
+    port: self.config.port,
     logging: self.config.logging || debug,
     freezeTableName: true
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-relationaldb",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Relational data store for jsonapi-server.",
   "keywords": [
     "json:api",


### PR DESCRIPTION
Oops, we forgot to pass down the database hostname and port to the underlying sequelize module. This PR enables us to talk to a remote database.