### PR TITLE
Make it easier to populate an empty database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@
 2015-12-15 - Enable connections to remote databases
 2015-12-15 - v1.0.3
 2015-12-15 - Make it easier to populate an empty database
-2015-12-15 - v1.0.3
+2015-12-15 - v1.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@
 2015-12-15 - v1.0.2
 2015-12-15 - Enable connections to remote databases
 2015-12-15 - v1.0.3
+2015-12-15 - Make it easier to populate an empty database
+2015-12-15 - v1.0.3

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -41,13 +41,14 @@ SqlStore.prototype.initialise = function(resourceConfig) {
 
 SqlStore.prototype.populate = function(callback) {
   var self = this;
-  self.sequelize.sync({ force: true }).asCallback(function(err) {
+  self.sequelize.sync({ force: true, logging: self.config.logging || debug }).asCallback(function(err) {
     if (err) throw err;
 
     async.map(self.resourceConfig.examples, function(exampleJson, asyncCallback) {
       self.create({ request: { type: self.resourceConfig.resource } }, exampleJson, asyncCallback);
     }, callback);
   });
+  return self;
 };
 
 SqlStore.prototype._buildModels = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-relationaldb",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Relational data store for jsonapi-server.",
   "keywords": [
     "json:api",


### PR DESCRIPTION
We've found when moving to staging that initialising a new database with the correct tables is a bit of a hassle.

It's now possible to call populate on a relationStore to cause it to synchronise (read: create tables and indexes, then populate it with the example resources). It will also output any+all SQL it produces either via the `logging` option, or as debug info via `DEBUG=jsonApi:store:relationaldb`
```
jsonApi.define({
  resource: 'articles',
  handlers: new RelationalStore(config.jsonapi.store.relational).populate(),
  ...
```