### PR TITLE
Debug log Sequelize when enabled and namespace it

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ jsonApi.define({
 });
 ```
 
+**Note:** the `logging` property controls the logging of the emitted SQL and can either be `false` (which will mean it will be captured by the internal debugging module under the namespace `jsonApi:store:relationaldb:sequelize`) or a user provided function (e.g. `console.log`) to which a string containing the information to be logged will be passed as the first argument.
+
 ### Features
 
  * Search, Find, Create, Delete, Update

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -30,7 +30,7 @@ SqlStore.prototype.initialise = function(resourceConfig) {
     dialect: self.config.dialect,
     host: self.config.host,
     port: self.config.port,
-    logging: self.config.logging || debug,
+    logging: self.config.logging || require("debug")("jsonApi:store:relationaldb:sequelize"),
     freezeTableName: true
   });
 


### PR DESCRIPTION
Add a sub-namespace for Sequelize logging of the emitted SQL and clarify the usage of the `logging` property in the store configuration in the documentation.
