### PR TITLE
Allowing multiple resources to share a Sequelize instance and database

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jsonApi.define({
 Getting this data store to production isn't too bad...
 
 1. Bring up your relational database stack.
-2. Create the database.
+2. Create the database(s).
 3. Create the database tables. You can call `(new RelationalDbStore()).populate()` to have this module attempt to create the require tables. If you enable debugging via `DEBUG=jsonApi:store:*` you'll see the create-table statements - you can target a local database, call populate(), grab the queries, review them and finally run them against your production stack manually.
 3. Deploy your code.
 4. Celebrate.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jsonApi.define({
     dialect: "mysql",
     host: "localhost",
     port: 3306,
+    database: "jsonapi", // If not provided, defaults to the name of the resource
     username: "root",
     password: null,
     logging: false
@@ -50,8 +51,8 @@ jsonApi.define({
 Getting this data store to production isn't too bad...
 
 1. Bring up your relational database stack.
-2. Create the databases - one database per resources, named identically. A `people` resource will need a `people` database.
-3. Create the database tables. You can call `(new RelationalDbStore()).populate()` to have this module attempt to create the require tables. If you enable debugging via `DEBUG=jsonApi:store:*` you'll see the create-table statements - you can target a local database, call poplate(), grab the queries, review them and finally run them against your production stack manually.
+2. Create the database.
+3. Create the database tables. You can call `(new RelationalDbStore()).populate()` to have this module attempt to create the require tables. If you enable debugging via `DEBUG=jsonApi:store:*` you'll see the create-table statements - you can target a local database, call populate(), grab the queries, review them and finally run them against your production stack manually.
 3. Deploy your code.
 4. Celebrate.
 

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -2,6 +2,7 @@
 // http://docs.sequelizejs.com/en/latest/
 var Sequelize = require("sequelize");
 var async = require("async");
+var md5 = require("js-md5");
 var debug = require("debug")("jsonApi:store:relationaldb");
 var _ = {
   pick: require("lodash.pick"),
@@ -13,6 +14,8 @@ var SqlStore = module.exports = function SqlStore(config) {
   this.config = config;
 };
 
+SqlStore._sequelizeInstances = {};
+
 /**
   Handlers readiness status. This should be set to `true` once all handlers are ready to process requests.
  */
@@ -20,19 +23,36 @@ SqlStore.prototype.ready = false;
 
 /**
   initialise gets invoked once for each resource that uses this hander.
-  In this instance, we're allocating an array in our in-memory data store.
+  In this instance, we're instantiating a Sequelize instance and building models.
  */
 SqlStore.prototype.initialise = function(resourceConfig) {
   var self = this;
   self.resourceConfig = resourceConfig;
 
-  self.sequelize = new Sequelize(resourceConfig.resource, self.config.username, self.config.password, {
+  var sequelizeArgs = [self.config.database || resourceConfig.resource, self.config.username, self.config.password, {
     dialect: self.config.dialect,
     host: self.config.host,
     port: self.config.port,
     logging: self.config.logging || debug,
     freezeTableName: true
-  });
+  }];
+
+  // To prevent too many open connections, we will store all Sequelize instances in a hash map.
+  // Index the hash map by a hash of the entire config object. If the same config is passed again,
+  // reuse the existing Sequelize connection resource instead of opening a new one.
+
+  var instanceId = md5(JSON.stringify(sequelizeArgs));
+
+  if (!SqlStore._sequelizeInstances[instanceId]) {
+    var bindArgs = [Sequelize].concat(sequelizeArgs);
+    SqlStore._sequelizeInstances[instanceId] = {
+      instance: new (Function.prototype.bind.apply(Sequelize, bindArgs)),
+      synced: false
+    };
+  }
+
+  self.sequelizeInstanceInfo = SqlStore._sequelizeInstances[instanceId];
+  self.sequelize = self.sequelizeInstanceInfo.instance;
 
   self._buildModels();
 
@@ -41,13 +61,23 @@ SqlStore.prototype.initialise = function(resourceConfig) {
 
 SqlStore.prototype.populate = function(callback) {
   var self = this;
-  self.sequelize.sync({ force: true }).asCallback(function(err) {
+
+  // `sync` should only be called once per instance of Sequelize, but example data should be
+  // populated for each resource.
+  if (!self.sequelizeInstanceInfo.synced) {
+    self.sequelize.sync({ force: true }).asCallback(onSynced);
+  } else {
+    onSynced();
+  }
+
+  function onSynced(err) {
     if (err) throw err;
 
+    self.sequelizeInstanceInfo.synced = true;
     async.map(self.resourceConfig.examples, function(exampleJson, asyncCallback) {
       self.create({ request: { type: self.resourceConfig.resource } }, exampleJson, asyncCallback);
     }, callback);
-  });
+  }
 };
 
 SqlStore.prototype._buildModels = function() {

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -64,12 +64,6 @@ SqlStore.prototype.populate = function(callback) {
 
   // `sync` should only be called once per instance of Sequelize, but example data should be
   // populated for each resource.
-  if (!self.sequelizeInstanceInfo.synced) {
-    self.sequelize.sync({ force: true }).asCallback(onSynced);
-  } else {
-    onSynced();
-  }
-
   function onSynced(err) {
     if (err) throw err;
 
@@ -77,6 +71,12 @@ SqlStore.prototype.populate = function(callback) {
     async.map(self.resourceConfig.examples, function(exampleJson, asyncCallback) {
       self.create({ request: { type: self.resourceConfig.resource } }, exampleJson, asyncCallback);
     }, callback);
+  }
+
+  if (!self.sequelizeInstanceInfo.synced) {
+    self.sequelize.sync({ force: true }).asCallback(onSynced);
+  } else {
+    onSynced();
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "async": "1.5.0",
     "debug": "2.2.0",
+    "js-md5": "^0.4.0",
     "lodash.assign": "3.2.0",
     "lodash.omit": "3.1.0",
     "lodash.pick": "3.1.0",


### PR DESCRIPTION
Relates to #22.

* Allows multiple resources to share the same database (but is backwards-compatible by default).
* When the connection arguments passed to the Sequelize constructor are identical, shares the Sequelize instance as opposed to opening a new connection to the database server.