### PR TITLE
Returning the correct callback in populate()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-06-07 - v1.2.1
+- 2016-06-07 - Fixing bug in populate()
 - 2016-05-31 - v1.2.0
 - 2016-05-31 - Use latest `jsonapi-server` processed filter
 - 2016-05-13 - v1.1.0

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -87,9 +87,7 @@ SqlStore.prototype.populate = function(callback) {
     function(cb) {
       async.each(self.resourceConfig.examples, function(exampleJson, ecb) {
         var validation = Joi.validate(exampleJson, self.resourceConfig.attributes);
-        if (validation.error) {
-          return asyncCallback(validation.error);
-        }
+        if (validation.error) return ecb(validation.error);
         self.create({ request: { type: self.resourceConfig.resource } }, validation.value, ecb);
       }, cb);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-relationaldb",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Relational data store for jsonapi-server.",
   "keywords": [
     "json:api",


### PR DESCRIPTION
The wrong callback was being returned in the populate method when there's a validation error.