### PR TITLE
Fix filtering

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -262,7 +262,7 @@ SqlStore.prototype._filterInclude = function(relationships) {
 SqlStore.prototype._generateSearchBlock = function(request) {
   var self = this;
 
-  var attributesToFilter = _.omit(request.params.processedFilter, Object.keys(self.relations));
+  var attributesToFilter = _.omit(request.processedFilter, Object.keys(self.relations));
   var searchBlock = SqlStore._getSearchBlock(attributesToFilter);
   return searchBlock;
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "blanket": "1.1.9",
     "coveralls": "^2.11.9",
     "eslint": "^2.11.0",
-    "jsonapi-server": "^1.10.0",
+    "jsonapi-server": "^1.15.0",
     "mocha": "^2.5.3",
     "mocha-lcov-reporter": "^1.2.0",
     "mocha-performance": "^0.1.1",


### PR DESCRIPTION
Correctly retrieve processed filter from request.

When converting the handler to use the server provided processed filter we unfortunately introduced a nasty regression which went unnoticed because server-side filtering still filtered the results and allowed the tests to pass.

Derp!

![](http://i.giphy.com/QrKRsPlBdwsrm.gif)