### PR TITLE
Deletion errors should break transactions

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -27,7 +27,7 @@ SqlStore._sequelizeInstances = Object.create(null);
 SqlStore.prototype.ready = false;
 
 SqlStore._checkMinServerVersion = function() {
-  var serverVersion = require('jsonapi-server')._version;
+  var serverVersion = require("jsonapi-server")._version;
   if (!serverVersion) return;
   if (semver.lt(serverVersion, MIN_SERVER_VERSION)) {
     throw new Error("This version of jsonapi-store-mongodb requires jsonapi-server>=" + MIN_SERVER_VERSION + ".");
@@ -55,8 +55,8 @@ SqlStore.prototype.initialise = function(resourceConfig) {
   // Index the hash map by a hash of the entire config object. If the same config is passed again,
   // reuse the existing Sequelize connection resource instead of opening a new one.
 
-  var md5sum = crypto.createHash('md5');
-  var instanceId = md5sum.update(JSON.stringify(sequelizeArgs)).digest('hex');
+  var md5sum = crypto.createHash("md5");
+  var instanceId = md5sum.update(JSON.stringify(sequelizeArgs)).digest("hex");
   var instances = SqlStore._sequelizeInstances;
 
   if (!instances[instanceId]) {
@@ -344,8 +344,8 @@ SqlStore.prototype._clearAndSetMany = function(relationModel, prop, theResource,
     if (deleteError) return taskCallback(deleteError);
 
     async.map(prop, function(item, acallback) {
-      relationModel.create(item, t).asCallback(function(err4, newRelationModel) {
-        if (err4) return acallback(err4);
+      relationModel.create(item, t).asCallback(function(err, newRelationModel) {
+        if (err) return acallback(err);
 
         theResource["add" + ucKeyName](newRelationModel, t).asCallback(acallback);
       });
@@ -359,8 +359,8 @@ SqlStore.prototype._clearAndSetOne = function(relationModel, prop, theResource, 
     if (!prop) {
       theResource["set" + ucKeyName](null, t).asCallback(taskCallback);
     } else {
-      relationModel.create(prop, t).asCallback(function(err3, newRelationModel) {
-        if (err3) return taskCallback(err3);
+      relationModel.create(prop, t).asCallback(function(err, newRelationModel) {
+        if (err) return taskCallback(err);
 
         theResource["set" + ucKeyName](newRelationModel, t).asCallback(taskCallback);
       });

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -337,6 +337,42 @@ SqlStore.prototype._dealWithTransaction = function(done, callback) {
   });
 };
 
+SqlStore.prototype._clearAndSetMany = function(relationModel, prop, theResource, keyName, ucKeyName, t, taskCallback) {
+  async.map(theResource[keyName] || [], function(deadRow, acallback) {
+    deadRow.destroy(t).asCallback(acallback);
+  }, function(deleteError) {
+    if (deleteError) return taskCallback(deleteError);
+
+    async.map(prop, function(item, acallback) {
+      relationModel.create(item, t).asCallback(function(err4, newRelationModel) {
+        if (err4) return acallback(err4);
+
+        theResource["add" + ucKeyName](newRelationModel, t).asCallback(acallback);
+      });
+    }, taskCallback);
+  });
+};
+
+SqlStore.prototype._clearAndSetOne = function(relationModel, prop, theResource, keyName, ucKeyName, t, taskCallback) {
+  var next = function(deleteError) {
+    if (deleteError) return taskCallback(deleteError);
+    if (!prop) {
+      theResource["set" + ucKeyName](null, t).asCallback(taskCallback);
+    } else {
+      relationModel.create(prop, t).asCallback(function(err3, newRelationModel) {
+        if (err3) return taskCallback(err3);
+
+        theResource["set" + ucKeyName](newRelationModel, t).asCallback(taskCallback);
+      });
+    }
+  }
+  if (theResource[keyName]) {
+    theResource[keyName].destroy(t).asCallback(next);
+  } else {
+    next();
+  }
+};
+
 SqlStore.prototype._clearAndSetRelationTables = function(theResource, partialResource, t, callback) {
   var self = this;
 
@@ -347,34 +383,13 @@ SqlStore.prototype._clearAndSetRelationTables = function(theResource, partialRes
     var relationModel = self.relations[relationName];
 
     var keyName = self.resourceConfig.resource + "-" + relationName;
-    var uc = keyName[0].toUpperCase() + keyName.slice(1, keyName.length);
+    var ucKeyName = keyName[0].toUpperCase() + keyName.slice(1, keyName.length);
 
     tasks[relationName] = function(taskCallback) {
       if (prop instanceof Array) {
-        (theResource[keyName] || []).map(function(deadRow) {
-          deadRow.destroy(t);
-        });
-
-        async.map(prop, function(item, acallback) {
-          relationModel.create(item, t).asCallback(function(err4, newRelationModel) {
-            if (err4) return acallback(err4);
-
-            theResource["add" + uc](newRelationModel, t).asCallback(acallback);
-          });
-        }, taskCallback);
+        self._clearAndSetMany(relationModel, prop, theResource, keyName, ucKeyName, t, taskCallback);
       } else {
-        if (theResource[keyName]) {
-          theResource[keyName].destroy(t);
-        }
-        if (!prop) {
-          theResource["set" + uc](null, t).asCallback(taskCallback);
-        } else {
-          relationModel.create(prop, t).asCallback(function(err3, newRelationModel) {
-            if (err3) return taskCallback(err3);
-
-            theResource["set" + uc](newRelationModel, t).asCallback(taskCallback);
-          });
-        }
+        self._clearAndSetOne(relationModel, prop, theResource, keyName, ucKeyName, t, taskCallback);
       }
     };
   });


### PR DESCRIPTION
When deleting old records from a table, if the deletion fails we should be failing the transaction and doing a rollback. Right now, those failed deletions live on in the database.