### PR TITLE
Use READ_COMMITTED transaction isolation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "extends": "eslint:recommended",
   "globals": {
   },
   "env": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-07-04 - v1.2.4
+- 2016-07-04 - Use stricter MySQL transaction isolation READ_COMMITTED
 - 2016-07-01 - v1.2.3
 - 2016-07-01 - Deletion errors fail transactions
 - 2016-06-29 - v1.2.2

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -306,7 +306,7 @@ SqlStore._getSearchBlock = function(filter) {
 SqlStore.prototype._dealWithTransaction = function(done, callback) {
   var self = this;
   var transactionOptions = {
-    isolationLevel: Sequelize.Transaction.ISOLATION_LEVELS.READ_UNCOMMITTED,
+    isolationLevel: Sequelize.Transaction.ISOLATION_LEVELS.READ_COMMITTED,
     autocommit: false
   };
   self.sequelize.transaction(transactionOptions).asCallback(function(err1, transaction) {
@@ -495,29 +495,31 @@ SqlStore.prototype.create = function(request, newResource, finishedCallback) {
 /**
   Delete a resource, given a resource type and and id.
  */
-SqlStore.prototype.delete = function(request, callback) {
+SqlStore.prototype.delete = function(request, finishedCallback) {
   var self = this;
 
-  self.baseModel.findAll({
-    where: { id: request.params.id },
-    include: self.relationArray
-  }).asCallback(function(findErr, results) {
-    if (findErr) return self._errorHandler(findErr, callback);
+  self._dealWithTransaction(finishedCallback, function(t, finishTransaction) {
+    self.baseModel.findAll({
+      where: { id: request.params.id },
+      include: self.relationArray
+    }).asCallback(function(findErr, results) {
+      if (findErr) return finishTransaction(findErr);
 
-    var theResource = results[0];
+      var theResource = results[0];
 
-    // If the resource doesn't exist, error
-    if (!theResource) {
-      return callback({
-        status: "404",
-        code: "ENOTFOUND",
-        title: "Requested resource does not exist",
-        detail: "There is no " + request.params.type + " with id " + request.params.id
+      // If the resource doesn't exist, error
+      if (!theResource) {
+        return finishTransaction({
+          status: "404",
+          code: "ENOTFOUND",
+          title: "Requested resource does not exist",
+          detail: "There is no " + request.params.type + " with id " + request.params.id
+        });
+      }
+
+      theResource.destroy(t).asCallback(function(deleteErr) {
+        return finishTransaction(deleteErr);
       });
-    }
-
-    theResource.destroy().asCallback(function(deleteErr) {
-      return callback(deleteErr);
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-relationaldb",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Relational data store for jsonapi-server.",
   "keywords": [
     "json:api",


### PR DESCRIPTION
We've found under heavy load we're getting some queries (16 in 30,000) leaving rogue rows hanging around in some of our resource's join tables. We're moving up one transaction isolation level to see if that fixes our race conditions. I've also wrapped the delete function in a transaction - we're not using that functionality in production so it's not the source of our issue however the test suite wouldn't pass without it.