### PR TITLE
Prevent ghost rows in the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-07-11 - v1.2.5
+- 2016-07-11 - Fixing bug when concurrently updating the same resource id
 - 2016-07-04 - v1.2.4
 - 2016-07-04 - Use stricter MySQL transaction isolation READ_COMMITTED
 - 2016-07-01 - v1.2.3

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -80,12 +80,12 @@ SqlStore.prototype.populate = function(callback) {
       self.baseModel.sync().asCallback(cb);
     },
     function(cb) {
-      async.each(self.relationArray, function(model, ecb) {
+      async.eachSeries(self.relationArray, function(model, ecb) {
         model.sync().asCallback(ecb);
       }, cb);
     },
     function(cb) {
-      async.each(self.resourceConfig.examples, function(exampleJson, ecb) {
+      async.eachSeries(self.resourceConfig.examples, function(exampleJson, ecb) {
         var validation = Joi.validate(exampleJson, self.resourceConfig.attributes);
         if (validation.error) return ecb(validation.error);
         self.create({ request: { type: self.resourceConfig.resource } }, validation.value, ecb);

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -321,7 +321,7 @@ SqlStore.prototype._dealWithTransaction = function(done, callback) {
       });
     };
     var rollback = function(e) {
-      debug("Err", e);
+      debug("Err", transaction.name, e);
       var a = function() {
         if (e instanceof Error) return self._errorHandler(e, done);
         return done(e);
@@ -338,9 +338,12 @@ SqlStore.prototype._dealWithTransaction = function(done, callback) {
 };
 
 SqlStore.prototype._clearAndSetMany = function(relationModel, prop, theResource, keyName, ucKeyName, t, taskCallback) {
-  async.map(theResource[keyName] || [], function(deadRow, acallback) {
-    deadRow.destroy(t).asCallback(acallback);
-  }, function(deleteError) {
+  var whereClause = { };
+  whereClause[theResource.type + "Id"] = theResource.id;
+  relationModel.destroy({
+    where: whereClause,
+    transaction: t.transaction
+  }).asCallback(function(deleteError) {
     if (deleteError) return taskCallback(deleteError);
 
     async.map(prop, function(item, acallback) {
@@ -354,7 +357,12 @@ SqlStore.prototype._clearAndSetMany = function(relationModel, prop, theResource,
 };
 
 SqlStore.prototype._clearAndSetOne = function(relationModel, prop, theResource, keyName, ucKeyName, t, taskCallback) {
-  var next = function(deleteError) {
+  var whereClause = { };
+  whereClause[theResource.type + "Id"] = theResource.id;
+  relationModel.destroy({
+    where: whereClause,
+    transaction: t.transaction
+  }).asCallback(function(deleteError) {
     if (deleteError) return taskCallback(deleteError);
     if (!prop) {
       theResource["set" + ucKeyName](null, t).asCallback(taskCallback);
@@ -365,12 +373,7 @@ SqlStore.prototype._clearAndSetOne = function(relationModel, prop, theResource, 
         theResource["set" + ucKeyName](newRelationModel, t).asCallback(taskCallback);
       });
     }
-  }
-  if (theResource[keyName]) {
-    theResource[keyName].destroy(t).asCallback(next);
-  } else {
-    next();
-  }
+  });
 };
 
 SqlStore.prototype._clearAndSetRelationTables = function(theResource, partialResource, t, callback) {

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -225,6 +225,15 @@ SqlStore.prototype._fixObject = function(json) {
 
 SqlStore.prototype._errorHandler = function(e, callback) {
   // console.log(e, e.stack);
+  if (e.message.match(/^ER_LOCK_DEADLOCK/)) {
+    return callback({
+      status: "500",
+      code: "EMODIFIED",
+      title: "Resource Just Changed",
+      detail: "The resource you tried to mutate was modified by another request. Your request has been aborted."
+    });
+  }
+
   return callback({
     status: "500",
     code: "EUNKNOWN",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-relationaldb",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Relational data store for jsonapi-server.",
   "keywords": [
     "json:api",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "blanket": "1.1.9",
     "coveralls": "^2.11.9",
     "eslint": "^2.11.0",
-    "jsonapi-server": "^1.15.0",
+    "jsonapi-server": "^1.15.4",
     "mocha": "^2.5.3",
     "mocha-lcov-reporter": "^1.2.0",
     "mocha-performance": "^0.1.1",


### PR DESCRIPTION
In master right now, under heavy load with multiple concurrent writes to the same resource, it's possible to end up with some ghost records in the relation tables.

For example creating a resource then running 10x concurrent updates whilst artificially slowing down each transaction to guarantee collisions will result in a relation table (that should contain just one record) looking something like this:
```
mysql> select * from `jsonapi-relationaldb-test`.`photos-photographer` WHERE id="froobar";
+-----+--------------------------------------+--------+------+--------------------------------------+
| uid | id                                   | type   | meta | photosId                             |
+-----+--------------------------------------+--------+------+--------------------------------------+
|   8 | froobar                              | people | NULL | NULL                                 |
|   9 | froobar                              | people | NULL | NULL                                 |
|  10 | froobar                              | people | NULL | ef0f3426-abe9-45d3-9142-fdb575a4b04f |
|  11 | froobar                              | people | NULL | ef0f3426-abe9-45d3-9142-fdb575a4b04f |
|  12 | froobar                              | people | NULL | ef0f3426-abe9-45d3-9142-fdb575a4b04f |
+-----+--------------------------------------+--------+------+--------------------------------------+
```

The issue occurs with concurrent transactions starting at the same time and loading the same `uid` from the relation table. All transactions attempt to delete from the table where `uid == 1` and proceed to insert their own records. Due to how each transaction deletes the same row, the transactions don't fail and we end up with garbage in the database.

Upping the transaction isolation level to the strictest form prevents this from happening, but also results in a full table lock. The solution is to change how we delete the the records in the relation table by deleting by foreign key instead of uid. This causes concurrent transactions to fail as expected and prevents junk in the database.

Instead of responding with a nasty MySQL table lock error, we're catching it and rewording it into something a bit more friendly - `The resource you tried to mutate was modified by another request. Your request has been aborted.`.

Following this PR, any concurrent writes to the same resource ID will result in the first write succeeding and all other concurrent writes to fail. Creating and updating different resources in parallel still works great.