### PR TITLE
Pin `sequelize-3.23.4`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-07-28 - v1.2.7
+- 2016-07-28 - Pin `sequelize-3.23.4`
 - 2016-07-18 - v1.2.6
 - 2016-07-18 - Fix case insensitive matches for PostgreSQL
 - 2016-07-18 - Enable multi-dialect support for tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-relationaldb",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Relational data store for jsonapi-server.",
   "keywords": [
     "json:api",
@@ -29,7 +29,7 @@
     "lodash.omit": "^4.3.0",
     "lodash.pick": "^4.2.1",
     "semver": "^5.3.0",
-    "sequelize": "^3.23.4"
+    "sequelize": "3.23.4"
   },
   "devDependencies": {
     "blanket": "^1.2.3",


### PR DESCRIPTION
Unfortunately Sequelize is not following their semver promise and they've broken the behaviour of `findAndCount` with inclusions in their latest release (`3.23.6`). We want to update to the latest release which includes a security fix, but the changes have a non-trivial impact in our code, so we're pinning our Sequelize dependency to `3.23.4` which behaves as we expected it to until we have the opportunity to investigate further.