### PR TITLE
Efficient searches filtered by related resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 2016-08-04 - v1.2.8
+- 2016-08-04 - Update `sequelize` dependency to latest version
+- 2016-08-04 - Optimised searches filtered by related resource
 - 2016-07-28 - v1.2.7
 - 2016-07-28 - Pin `sequelize-3.23.4`
 - 2016-07-18 - v1.2.6

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -11,6 +11,7 @@ var _ = {
   assign: require("lodash.assign"),
   omit: require("lodash.omit")
 };
+  var util = require('util');
 
 var MIN_SERVER_VERSION = "1.10.0";
 
@@ -242,30 +243,45 @@ SqlStore.prototype._errorHandler = function(e, callback) {
   });
 };
 
-SqlStore.prototype._filterInclude = function(relationships) {
+SqlStore.prototype._generateSearchIncludes = function(relationships) {
   var self = this;
-  relationships = _.pick(relationships, Object.keys(self.relations));
-
-  var includeBlock = Object.keys(self.relations).map(function(relationName) {
+  if (!relationships) {
+    return {
+      count: [],
+      findAll: Object.keys(self.relations).map(function(key) {
+        return self.relations[key];
+      })
+    }
+  }
+  var searchIncludes = Object.keys(self.relations).reduce(function(partialSearchIncludes, relationName) {
     var model = self.relations[relationName];
-    var matchingValue = relationships[relationName];
-    if (!matchingValue) return model;
+    partialSearchIncludes.findAll.push(model);
 
+    var matchingValue = relationships[relationName];
+    if (!matchingValue) return partialSearchIncludes;
     if (matchingValue instanceof Array) {
       matchingValue = matchingValue.filter(function(i) {
         return !(i instanceof Object);
       });
+      if (!matchingValue.length) return partialSearchIncludes;
     } else if (matchingValue instanceof Object) {
-      return model;
+      return partialSearchIncludes;
     }
-
-    return {
+    var includeClause = {
       model: model,
       where: { id: matchingValue }
     };
+    partialSearchIncludes.count.push(includeClause);
+    // replace simple model with clause
+    partialSearchIncludes.findAll.pop();
+    partialSearchIncludes.findAll.push(includeClause);
+    return partialSearchIncludes;
+  }, {
+    count: [],
+    findAll: []
   });
 
-  return includeBlock;
+  return searchIncludes;
 };
 
 SqlStore.prototype._generateSearchBlock = function(request) {
@@ -441,13 +457,12 @@ SqlStore.prototype._generateSearchOrdering = function(request) {
 };
 
 SqlStore.prototype._generateSearchPagination = function(request) {
-  if (!request.params.page) {
-    return { };
-  }
+  var page = request.params.page;
+  if (!page) return undefined;
 
   return {
-    limit: request.params.page.limit,
-    offset: request.params.page.offset
+    limit: page.limit,
+    offset: page.offset
   };
 };
 
@@ -457,20 +472,38 @@ SqlStore.prototype._generateSearchPagination = function(request) {
 SqlStore.prototype.search = function(request, callback) {
   var self = this;
 
-  var base = {
-    where: self._generateSearchBlock(request),
-    include: self._filterInclude(request.params.filter),
-    order: self._generateSearchOrdering(request)
-  };
-  var query = _.assign(base, self._generateSearchPagination(request));
-
-  self.baseModel.findAndCount(query).asCallback(function(err, result) {
-    debug(query, err, JSON.stringify(result));
-    if (err) return self._errorHandler(err, callback);
-
-    var records = result.rows.map(function(i){ return self._fixObject(i.toJSON()); });
-    debug("Produced", JSON.stringify(records));
-    return callback(null, records, result.count);
+  var options = { };
+  var where = self._generateSearchBlock(request);
+  if (where) {
+    options.where = where;
+  }
+  var includeBlocks = self._generateSearchIncludes(request.params.filter);
+  debug("includeBlocks", util.inspect(includeBlocks, { depth: null }))
+  if (includeBlocks.count.length) {
+    options.include = includeBlocks.count;
+  }
+  self.baseModel.count(options).asCallback(function(err, count) {
+    debug("Count", count);
+    if (includeBlocks.findAll.length) {
+      options.include = includeBlocks.findAll;
+    }
+    var order = self._generateSearchOrdering(request);
+    if (order) {
+      options.order = order;
+    }
+    var pagination = self._generateSearchPagination(request);
+    if (pagination) {
+      if (pagination.offset > 0 || pagination.limit <= count) {
+        _.assign(options, pagination);
+      }
+    }
+    self.baseModel.findAll(options).asCallback(function(err, result) {
+      debug(options, err, JSON.stringify(result));
+      if (err) return self._errorHandler(err, callback);
+      var records = result.map(function(i){ return self._fixObject(i.toJSON()); });
+      debug("Produced", JSON.stringify(records));
+      return callback(null, records, count);
+    });
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-relationaldb",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Relational data store for jsonapi-server.",
   "keywords": [
     "json:api",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash.omit": "^4.3.0",
     "lodash.pick": "^4.2.1",
     "semver": "^5.3.0",
-    "sequelize": "3.23.4"
+    "sequelize": "^3.23.6"
   },
   "devDependencies": {
     "blanket": "^1.2.3",


### PR DESCRIPTION
Only query with pagination when strictly necessary.

The search implementation will now optimise filtering by related resource id, for the common case where the pagination offset is `0` and the resource count is `<=` the pagination limit.

Unfortunately we couldn't find a straightforward way (short of *maybe* having hand-crafted queries) of avoiding badly performing sub-queries for the general case of filtering by related resource id with pagination.

The change in the way we count resources also enables us to cope with the behaviour changes in `count` in the latest `sequelize` version, so we take the opportunity to update our `sequelize` dependency to the latest available version which fixes a security issue.

The difference in performance can be easily seen for databases with 100k + resources, for the common filtering case without pagination or pagination from offset `0` with resources not exceeding the resource count.

Fixes #38.