### PR TITLE
Add option to inject sequelize instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ jsonApi.define({
 
 **Note:** the `logging` property controls the logging of the emitted SQL and can either be `false` (which will mean it will be captured by the internal debugging module under the namespace `jsonApi:store:relationaldb:sequelize`) or a user provided function (e.g. `console.log`) to which a string containing the information to be logged will be passed as the first argument.
 
+#### Alternative Usage - Provide Sequelize instance
+
+If you are already using sequelize or need to have access to the sequelize instance, you may provide an instance to the store to be used instead of having the store create a new instance from the given config.
+
+```javascript
+var RelationalDbStore = require("jsonapi-store-relationaldb");
+var Sequelize = require("Sequelize");
+
+var sequelize = new Sequelize("jsonapi", "root", null, {dialect: "mysql"}));
+
+jsonApi.define({
+  resource: "comments",
+  handlers: new RelationalDbStore({
+    sequelize: sequelize
+  })
+});
+```
+
 ### Features
 
  * Search, Find, Create, Delete, Update

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -43,30 +43,33 @@ SqlStore.prototype.initialise = function(resourceConfig) {
   var self = this;
   self.resourceConfig = resourceConfig;
 
-  var database = self.config.database || resourceConfig.resource;
-  var sequelizeArgs = [database, self.config.username, self.config.password, {
-    dialect: self.config.dialect,
-    host: self.config.host,
-    port: self.config.port,
-    logging: self.config.logging || require("debug")("jsonApi:store:relationaldb:sequelize"),
-    freezeTableName: true
-  }];
+  if (self.config.sequelize) {
+    self.sequelize = self.config.sequelize;
+  } else {
+    var database = self.config.database || resourceConfig.resource;
+    var sequelizeArgs = [database, self.config.username, self.config.password, {
+      dialect: self.config.dialect,
+      host: self.config.host,
+      port: self.config.port,
+      logging: self.config.logging || require("debug")("jsonApi:store:relationaldb:sequelize")
+    }];
 
-  // To prevent too many open connections, we will store all Sequelize instances in a hash map.
-  // Index the hash map by a hash of the entire config object. If the same config is passed again,
-  // reuse the existing Sequelize connection resource instead of opening a new one.
+    // To prevent too many open connections, we will store all Sequelize instances in a hash map.
+    // Index the hash map by a hash of the entire config object. If the same config is passed again,
+    // reuse the existing Sequelize connection resource instead of opening a new one.
 
-  var md5sum = crypto.createHash("md5");
-  var instanceId = md5sum.update(JSON.stringify(sequelizeArgs)).digest("hex");
-  var instances = SqlStore._sequelizeInstances;
+    var md5sum = crypto.createHash("md5");
+    var instanceId = md5sum.update(JSON.stringify(sequelizeArgs)).digest("hex");
+    var instances = SqlStore._sequelizeInstances;
 
-  if (!instances[instanceId]) {
-    var sequelize = Object.create(Sequelize.prototype);
-    Sequelize.apply(sequelize, sequelizeArgs);
-    instances[instanceId] = sequelize;
+    if (!instances[instanceId]) {
+      var sequelize = Object.create(Sequelize.prototype);
+      Sequelize.apply(sequelize, sequelizeArgs);
+      instances[instanceId] = sequelize;
+    }
+
+    self.sequelize = instances[instanceId];
   }
-
-  self.sequelize = instances[instanceId];
 
   self._buildModels();
 
@@ -114,7 +117,7 @@ SqlStore.prototype._buildModels = function() {
   relations = _.pick(self.resourceConfig.attributes, relations);
 
   var modelAttributes = self._joiSchemaToSequelizeModel(localAttributes);
-  self.baseModel = self.sequelize.define(self.resourceConfig.resource, modelAttributes, { timestamps: false });
+  self.baseModel = self.sequelize.define(self.resourceConfig.resource, modelAttributes, { timestamps: false, freezeTableName: true });
 
   self.relations = { };
   self.relationArray = [ ];


### PR DESCRIPTION
In order to allow more seamless usage of the database instance or more customized configurations, this adds a configuration option of 'sequelize' that will use that instance instead of creating a new instance.

This closes #39 .
