### PR TITLE
Fix typo

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -617,7 +617,7 @@ SqlStore.prototype.update = function(request, partialResource, finishedCallback)
         if (err) return finishTransaction(err);
 
         theResource.update(partialResource, t).asCallback(function(err3) {
-          if (err) return finishTransaction(err3);
+          if (err3) return finishTransaction(err3);
           return finishTransaction(null, partialResource);
         });
       });


### PR DESCRIPTION
Checking error after `theResource.update` was mistakingly checking `err`, when it should check `err3`.
this was blindly ignoring validation errors.

```javascript
        theResource.update(partialResource, t).asCallback(function(err3) {
          if (err) return finishTransaction(err3);
          return finishTransaction(null, partialResource);
        });
```
