### PR TITLE
sqlite: use 'storage' parameter from settings

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -48,6 +48,7 @@ SqlStore.prototype.initialise = function(resourceConfig) {
     dialect: self.config.dialect,
     host: self.config.host,
     port: self.config.port,
+    storage: self.config.storage || ":memory:",
     logging: self.config.logging || require("debug")("jsonApi:store:relationaldb:sequelize"),
     freezeTableName: true
   }];


### PR DESCRIPTION
allowing persistent sqlite db files (this is actually used in the lib/config.js but does not work, causing some headache when it comes to using an existing db-file)