### PR TITLE
fix(sequelize): properly freeze table names

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -49,7 +49,11 @@ SqlStore.prototype.initialise = function(resourceConfig) {
     host: self.config.host,
     port: self.config.port,
     logging: self.config.logging || require("debug")("jsonApi:store:relationaldb:sequelize"),
-    freezeTableName: true
+    define: {
+      // Set freezeTableName on all table definitions to prevent sequelize from pluralizing
+      // all table names by itself.
+      freezeTableName: true
+    }
   }];
 
   // To prevent too many open connections, we will store all Sequelize instances in a hash map.


### PR DESCRIPTION
According to http://docs.sequelizejs.com/manual/installation/getting-started.html#application-wide-model-options the property needs to be defined in the `define` block.