### PR TITLE
fix(deps): use only a single lodash dependency

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -6,12 +6,8 @@ var crypto = require("crypto");
 var debug = require("debug")("jsonApi:store:relationaldb");
 var Joi = require("joi");
 var semver = require("semver");
-var _ = {
-  pick: require("lodash.pick"),
-  assign: require("lodash.assign"),
-  omit: require("lodash.omit")
-};
-  var util = require('util');
+var _ = require("lodash");
+var util = require('util');
 
 var MIN_SERVER_VERSION = "1.10.0";
 

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     "async": "^1.5.2",
     "debug": "^2.2.0",
     "joi": "6.10.1",
-    "lodash.assign": "^4.0.9",
-    "lodash.omit": "^4.3.0",
-    "lodash.pick": "^4.2.1",
+    "lodash": "^4.3.0",
     "semver": "^5.3.0",
     "sequelize": "^3.23.6"
   },


### PR DESCRIPTION
Using the fragmented lodash dependency provides no benefit on the backend. Instead it will needlessly pollute the module cache and install fragmented lodash modules even though the full lodash is extremely likely to already be in the dependency graph.