### PR TITLE
use native arrays in postgres

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -113,7 +113,7 @@ SqlStore.prototype._buildModels = function() {
   });
   relations = _.pick(self.resourceConfig.attributes, relations);
 
-  var modelAttributes = self._joiSchemaToSequelizeModel(localAttributes);
+  var modelAttributes = self._joiSchemaToSequelizeModel(localAttributes, self.resourceConfig.dialect);
   self.baseModel = self.sequelize.define(self.resourceConfig.resource, modelAttributes, { timestamps: false });
 
   self.relations = { };
@@ -126,7 +126,7 @@ SqlStore.prototype._buildModels = function() {
   });
 };
 
-SqlStore.prototype._joiSchemaToSequelizeModel = function(joiSchema) {
+SqlStore.prototype._joiSchemaToSequelizeModel = function(joiSchema, dialect) {
   var model = {
     id: { type: new DataTypes.STRING(38), primaryKey: true },
     type: DataTypes.STRING,
@@ -150,17 +150,26 @@ SqlStore.prototype._joiSchemaToSequelizeModel = function(joiSchema) {
     if (attribute._type === "number") model[attributeName] = { type: DataTypes.INTEGER, allowNull: true };
     if (attribute._type === "boolean") model[attributeName] = { type: DataTypes.BOOLEAN, allowNull: true };
     if (attribute._type === "array") {
-      model[attributeName] = {
-        type: DataTypes.STRING,
-        allowNull: true,
-        get: function () {
-          var data = this.getDataValue(attributeName);
-          return data ? data.split(';') : []
-        },
-        set: function (val) {
-          this.setDataValue(attributeName, val.join(';'));
+      if (dialect === "postgres") {
+        switch (attribute._type.inner.items[0]._type) {
+          case "string": model[attribute] = {type: DataTypes.ARRAY(DataTypes.STRING), allowNull: true}; break;
+          case "number": model[attribute] = {type: DataTypes.ARRAY(DataTypes.NUMERIC), allowNull: true}; break;
+          case "boolean": model[attribute] = {type: DataTypes.ARRAY(DataTypes.BOOLEAN), allowNull: true}; break;
+        }
+      } else {
+        model[attributeName] = {
+          type: DataTypes.STRING,
+          allowNull: true,
+          get: function () {
+            var data = this.getDataValue(attributeName);
+            return data ? data.split(';') : []
+          },
+          set: function (val) {
+            this.setDataValue(attributeName, val.join(';'));
+          }
         }
       }
+
     }
   });
 


### PR DESCRIPTION
PostgreSQL has actual array type columns
Using them gives a significant performance improvement
as we are not doing in-memory serialization/deserializtion
anymore in Sequelize.

Signed-off-by: Arnav Gupta <arnav@codingblocks.com>