### PR TITLE
let user pass sync options in populate

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ When deploying schema changes, you'll need to correct your database schema - dat
 
 When changing columns in a production database, a typical approach might be to create a new table that is a clone of the table in production, copy all data from the production table into the new table, run an ALTER-TABLE command on the new table to adjust the columns (this may take a while and will lock the table), then run a RENAME-TABLES to swap the production table out for the new one.
 
+NOTE: 
+When populating database tables, you can use the `force` config option to DROP and CREATE tables.
+This is helpful in development stage, when your data doesn't matter and you
+want your Tables schemas to change according to the DAOs without having to
+manually write migrations
+
+```js
+(new RelationalDbStore()).populate({force: true}, () => {
+  //tables dropped and created
+})
+```
+
 ### Gotchas
 
 Relational databases don't differentiate between `undefined` and `null` values. `Joi` does differentiate between `undefined` and `null` values. Some `undefined` properties will pass validation, whilst `null` properties may not. For example, the default articles resource contains a `created` attribute of type `"date"` - this won't pass validation with a `null` value, so the Joi schema will need tweaking.

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -73,16 +73,21 @@ SqlStore.prototype.initialise = function(resourceConfig) {
   self.ready = true;
 };
 
-SqlStore.prototype.populate = function(callback) {
+SqlStore.prototype.populate = function(options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
   var self = this;
 
   var tasks = [
     function(cb) {
-      self.baseModel.sync().asCallback(cb);
+      self.baseModel.sync(options).asCallback(cb);
     },
     function(cb) {
       async.eachSeries(self.relationArray, function(model, ecb) {
-        model.sync().asCallback(ecb);
+        model.sync(options).asCallback(ecb);
       }, cb);
     },
     function(cb) {


### PR DESCRIPTION
This allows users to pass `{force: true}` for example
to force migrate the db schema

Signed-off-by: Arnav Gupta <arnav@codingblocks.com>