### PR TITLE
sequelize: use UUID types for 'id' field

### DIFF
--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -2,7 +2,11 @@ var DataTypes = require('sequelize').DataTypes
 
 exports.joiSchemaToSequelizeModel = function (resourceName, joiSchema) {
   var model = {
-    id: { type: new DataTypes.STRING(38), primaryKey: true },
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true
+    },
     type: {
       type: DataTypes.VIRTUAL, // We do not actually save this to DB, but API needs this
       set: function (val) {

--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -2,7 +2,11 @@ var DataTypes = require('sequelize').DataTypes
 
 exports.joiSchemaToSequelizeModel = function (resourceName, joiSchema) {
   var model = {
-    id: { type: new DataTypes.STRING(38), primaryKey: true },
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true
+    },
     type: {
       type: DataTypes.VIRTUAL, // We do not actually save this to DB, but API needs this
       set: function (val) {

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -528,7 +528,17 @@ SqlStore.prototype.find = function (request, callback) {
     where: { id: request.params.id },
     include: self.relationArray
   }).asCallback(function (err, theResource) {
-    if (err) return self._errorHandler(err, callback)
+    if (err) {
+      if (err.original.code === '22P02') {
+        return callback(new SqlStoreError({
+          status: '404',
+          code: 'ENOTFOUND',
+          title: 'Requested resource does not exist',
+          detail: 'The' + request.params.id + ' for ' + request.params.type + ' is of wrong format. (Make sure it is UUID)'
+        }))
+      }
+      return self._errorHandler(err, callback)
+    }
 
     // If the resource doesn't exist, error
     if (!theResource) {
@@ -576,7 +586,17 @@ SqlStore.prototype.delete = function (request, finishedCallback) {
       where: { id: request.params.id },
       include: self.relationArray
     }).asCallback(function (findErr, results) {
-      if (findErr) return finishTransaction(findErr)
+      if (findErr) {
+        if (findErr.original.code === '22P02') {
+          return finishTransaction({
+            status: '404',
+            code: 'ENOTFOUND',
+            title: 'Requested resource does not exist',
+            detail: 'The' + request.params.id + ' for ' + request.params.type + ' is of wrong format. (Make sure it is UUID)'
+          })
+        }
+        return finishTransaction(findErr)
+      }
 
       var theResource = results[0]
 
@@ -610,7 +630,17 @@ SqlStore.prototype.update = function (request, partialResource, finishedCallback
       include: self.relationArray,
       transaction: t.transaction
     }).asCallback(function (err2, theResource) {
-      if (err2) return finishTransaction(err2)
+      if (err2) {
+        if (err2.original.code === '22P02') {
+          return finishTransaction({
+            status: '404',
+            code: 'ENOTFOUND',
+            title: 'Requested resource does not exist',
+            detail: 'The' + request.params.id + ' for ' + request.params.type + ' is of wrong format. (Make sure it is UUID)'
+          })
+        }
+        return finishTransaction(err2)
+      }
 
       // If the resource doesn't exist, error
       if (!theResource) {

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -529,6 +529,7 @@ SqlStore.prototype.find = function (request, callback) {
     include: self.relationArray
   }).asCallback(function (err, theResource) {
     if (err) {
+      // We get a 22P02 error if the UUID format is wrong
       if (err.original.code === '22P02') {
         return callback(new SqlStoreError({
           status: '404',
@@ -587,6 +588,7 @@ SqlStore.prototype.delete = function (request, finishedCallback) {
       include: self.relationArray
     }).asCallback(function (findErr, results) {
       if (findErr) {
+        // We get a 22P02 error if the UUID format is wrong
         if (findErr.original.code === '22P02') {
           return finishTransaction({
             status: '404',
@@ -631,6 +633,7 @@ SqlStore.prototype.update = function (request, partialResource, finishedCallback
       transaction: t.transaction
     }).asCallback(function (err2, theResource) {
       if (err2) {
+        // We get a 22P02 error if the UUID format is wrong
         if (err2.original.code === '22P02') {
           return finishTransaction({
             status: '404',


### PR DESCRIPTION
UUID type is supported by Sequelize
internally, for SQLite it gets turned into a STRING(38),
but for MySQL and PostgreSQL it gives better performance
as those databases have UUID type and they can index
UUID values automatically.

Also, set default UUID value to UUIDV4 as used by
jsonapi-server (in lib/routes/create.js)

Signed-off-by: Arnav Gupta <arnav@codingblocks.com>