### PR TITLE
When creating a field, use Schema length and/or max validation fields as varchar lengths

### DIFF
--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -31,8 +31,16 @@ module.exports = class {
     for (let attributeName of Object.keys(joiSchema)) {
       const attribute = joiSchema[attributeName]
       if (attribute._type === 'string') {
+        //if the schema defines a length or max value, set the field
+        const lengths = attribute._tests.filter(test => test.name==='max' || test.name==='length')
+        let length
+        if(lengths.length === 1) {
+          length = lengths[0].arg
+        } else if (lengths.length === 2) {
+          length = Math.max(lengths[0].arg, lengths[1].arg)
+        }
         this[attributeName] = {
-          type: DataTypes.STRING,
+          type: DataTypes.STRING(length),
           allowNull: true
         }
       }

--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -31,10 +31,10 @@ module.exports = class {
     for (let attributeName of Object.keys(joiSchema)) {
       const attribute = joiSchema[attributeName]
       if (attribute._type === 'string') {
-        //if the schema defines a length or max value, set the field
-        const lengths = attribute._tests.filter(test => test.name==='max' || test.name==='length')
+        //  if the schema defines a length or max value, set the field
+        const lengths = attribute._tests.filter(test => test.name === 'max' || test.name === 'length')
         let length
-        if(lengths.length === 1) {
+        if (lengths.length === 1) {
           length = lengths[0].arg
         } else if (lengths.length === 2) {
           length = Math.max(lengths[0].arg, lengths[1].arg)


### PR DESCRIPTION
When joiSchema has `max` or `length` defined, set the STRING (varchar) datatype length accordingly